### PR TITLE
Fix old password behavior

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -207,7 +207,7 @@ in {
       installDir = "${stateDir}/valheim-server-modded";
       # If passwordEnvFile is provided then use environment variable, else insert password in unit file directly.
       # Assertions ensure that other cases are not possible.
-      serverPassword = if cfg.passwordEnvFile != null then "\"\${VH_SERVER_PASSWORD}\"" else cfg.password;
+      serverPassword = if builtins.isPath cfg.passwordEnvFile then "\"\${VH_SERVER_PASSWORD}\"" else cfg.password;
     in {
       valheim = {
         description = "Valheim dedicated server";
@@ -308,7 +308,7 @@ in {
         in {
           Type = "exec";
           User = "valheim";
-          EnvironmentFile = lib.mkIf (cfg.passwordEnvFile != null) cfg.passwordEnvFile;
+          EnvironmentFile = lib.mkIf (builtins.isPath cfg.passwordEnvFile) cfg.passwordEnvFile;
           ExecStart = let
             valheimServerPkg =
               if (cfg.bepinexMods != [])
@@ -349,18 +349,18 @@ in {
         assertion = cfg.worldName != "";
         message = "The world name must not be empty.";
       }
-      # {
-      #   assertion = cfg.password != null && cfg.passwordEnvFile != null;
-      #   message = "Please provide only one of password or passwordEnvFile";
-      # }
       {
-        assertion = cfg.passwordEnvFile != null && ! builtins.pathExists cfg.passwordEnvFile;
+        assertion = cfg.password != "" && builtins.isPath cfg.passwordEnvFile;
+        message = "Please provide only one of password or passwordEnvFile";
+      }
+      {
+        assertion = builtins.isPath cfg.passwordEnvFile && ! builtins.pathExists cfg.passwordEnvFile;
         message = "Environment file for the password was provided but does not exist.";
       }
-      # {
-      #   assertion = cfg.password == null && cfg.passwordEnvFile == null;
-      #   message = "Password must be provided at least one way.";
-      # }
+      {
+        assertion = cfg.password == "" && ! builtins.isPath cfg.passwordEnvFile;
+        message = "Password must be provided at least one way.";
+      }
     ];
   };
 }

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -350,17 +350,13 @@ in {
         message = "The world name must not be empty.";
       }
       {
-        assertion = (cfg.password != "") != (builtins.isPath cfg.passwordEnvFile);
-        message = "Please provide exactly one of password or passwordEnvFile";
+        assertion = (cfg.password != null && cfg.password != "") != (builtins.isPath cfg.passwordEnvFile);
+        message = "Please provide either password or passwordEnvFile but not both";
       }
       {
         assertion = ! builtins.isPath cfg.passwordEnvFile || builtins.pathExists cfg.passwordEnvFile;
         message = "Environment file for the password was provided but does not exist.";
       }
-      #{
-      #  assertion = cfg.password == "" && ! builtins.isPath cfg.passwordEnvFile;
-      #  message = "Password must be provided at least one way.";
-      #}
     ];
   };
 }

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -350,11 +350,11 @@ in {
         message = "The world name must not be empty.";
       }
       {
-        assertion = (cfg.password != null && cfg.password != "") != (builtins.isPath cfg.passwordEnvFile);
+        assertion = (cfg.password != null && cfg.password != "") != (cfg.passwordEnvFile != null);
         message = "Please provide either password or passwordEnvFile but not both";
       }
       {
-        assertion = ! builtins.isPath cfg.passwordEnvFile || builtins.pathExists cfg.passwordEnvFile;
+        assertion = cfg.passwordEnvFile == null || builtins.pathExists cfg.passwordEnvFile;
         message = "Environment file for the password was provided but does not exist.";
       }
     ];

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -207,7 +207,7 @@ in {
       installDir = "${stateDir}/valheim-server-modded";
       # If passwordEnvFile is provided then use environment variable, else insert password in unit file directly.
       # Assertions ensure that other cases are not possible.
-      serverPassword = if builtins.isPath cfg.passwordEnvFile then "\"\${VH_SERVER_PASSWORD}\"" else cfg.password;
+      serverPassword = if cfg.passwordEnvFile != null then "\"\${VH_SERVER_PASSWORD}\"" else cfg.password;
     in {
       valheim = {
         description = "Valheim dedicated server";
@@ -308,7 +308,7 @@ in {
         in {
           Type = "exec";
           User = "valheim";
-          EnvironmentFile = lib.mkIf (builtins.isPath cfg.passwordEnvFile) cfg.passwordEnvFile;
+          EnvironmentFile = lib.mkIf (cfg.passwordEnvFile != null) cfg.passwordEnvFile;
           ExecStart = let
             valheimServerPkg =
               if (cfg.bepinexMods != [])

--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -350,17 +350,17 @@ in {
         message = "The world name must not be empty.";
       }
       {
-        assertion = cfg.password != "" && builtins.isPath cfg.passwordEnvFile;
-        message = "Please provide only one of password or passwordEnvFile";
+        assertion = (cfg.password != "") != (builtins.isPath cfg.passwordEnvFile);
+        message = "Please provide exactly one of password or passwordEnvFile";
       }
       {
-        assertion = builtins.isPath cfg.passwordEnvFile && ! builtins.pathExists cfg.passwordEnvFile;
+        assertion = ! builtins.isPath cfg.passwordEnvFile || builtins.pathExists cfg.passwordEnvFile;
         message = "Environment file for the password was provided but does not exist.";
       }
-      {
-        assertion = cfg.password == "" && ! builtins.isPath cfg.passwordEnvFile;
-        message = "Password must be provided at least one way.";
-      }
+      #{
+      #  assertion = cfg.password == "" && ! builtins.isPath cfg.passwordEnvFile;
+      #  message = "Password must be provided at least one way.";
+      #}
     ];
   };
 }


### PR DESCRIPTION
The introduction of the new passwordEnvFile config option broke the old password config. This was mainly an issue in the asserts. Should be fixed now.