### PR TITLE
bug: remove assertion that always fails on password files

### DIFF
--- a/nixos-modules/valheim.nix
+++ b/nixos-modules/valheim.nix
@@ -353,10 +353,6 @@ in {
         assertion = (cfg.password != null && cfg.password != "") != (cfg.passwordEnvFile != null);
         message = "Please provide either password or passwordEnvFile but not both";
       }
-      {
-        assertion = cfg.passwordEnvFile == null || builtins.pathExists cfg.passwordEnvFile;
-        message = "Environment file for the password was provided but does not exist.";
-      }
     ];
   };
 }


### PR DESCRIPTION
while it'd be nice to check the password file exists, the assertion always fails for me, as it's done at evaluation time which means the file needs to be git tracked for the flake to see it. Issues there with committing secrets - undoing the purpose of the password file approach :)

If this works for you and you want it to remain a downstream patch I'm fine with that