### PR TITLE
valheim-server: 0.220.5 -> 0.221.4

### DIFF
--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "valheim-server";
-  version = "0.220.5";
+  version = "0.221.4";
   src = fetchSteam {
     inherit (finalAttrs) name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "18007466826975597";
-    hash = "sha256-8UdoLzKiu8CEztqwTHGP5M3RdrrVUTmAwN6Cqt9R+v8=";
+    manifestId = "8626142906162840635";
+    hash = "sha256-rIJlTVPTXElYd6UsEBJ3bMV0qZeSPClX5ctXLDCvglY=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.


### PR DESCRIPTION
Update Valheim Server to the newest version.

Note you need newer version of DepotDownloader than what currently exists in NixOS 25.05 Stable (3.1.0), the version 3.4.0 from nixos-unstable works