### PR TITLE
Update valheim-server to the latest manifest

### DIFF
--- a/pkgs/valheim-server/default.nix
+++ b/pkgs/valheim-server/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   name = "valheim-server";
-  version = "0.221.4";
+  version = "0.221.4.1";
   src = fetchSteam {
     inherit (finalAttrs) name;
     appId = "896660";
     depotId = "896661";
-    manifestId = "8626142906162840635";
-    hash = "sha256-rIJlTVPTXElYd6UsEBJ3bMV0qZeSPClX5ctXLDCvglY=";
+    manifestId = "3580572581606309980";
+    hash = "sha256-ayWzeDseL0nz9xjNz+W9TUv/PY/wJUmB8knZ/1bJbfk=";
   };
 
   # Skip phases that don't apply to prebuilt binaries.


### PR DESCRIPTION
New Valheim manifest version released, related to this Unity Security Advisory: https://unity.com/security/sept-2025-01

Note that I just added the .1 version to the end, as it looks like the official version number hasn't changed